### PR TITLE
change rest template creation from DI to new to avoid spring ribbon.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,10 @@ target/
 customer/target/
 item/target/
 order/target/
-
 bill/target/
 shipping/target/
+*.classpath
+*.project
 pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup

--- a/bill/src/main/java/onlineshop/bill/client/CustomerClient.java
+++ b/bill/src/main/java/onlineshop/bill/client/CustomerClient.java
@@ -17,7 +17,6 @@ import org.slf4j.LoggerFactory;
 @Service
 public class CustomerClient {
 	private static final Logger logger = LoggerFactory.getLogger(CustomerClient.class);
-	@Autowired
 	RestTemplate restTemplate = new RestTemplate();
 	
 	@Autowired

--- a/bill/src/main/java/onlineshop/bill/client/ItemClient.java
+++ b/bill/src/main/java/onlineshop/bill/client/ItemClient.java
@@ -19,8 +19,7 @@ import org.slf4j.LoggerFactory;
 public class ItemClient {
 	private static final Logger logger = LoggerFactory.getLogger(ItemClient.class);
 	
-	@Autowired
-	 RestTemplate restTemplate;
+	 RestTemplate restTemplate = new RestTemplate();
 
 	@Autowired
 	private DiscoveryClient discoveryClient;

--- a/bill/src/main/java/onlineshop/bill/client/OrderClient.java
+++ b/bill/src/main/java/onlineshop/bill/client/OrderClient.java
@@ -19,8 +19,7 @@ import org.slf4j.LoggerFactory;
 public class OrderClient {
 	private static final Logger logger = LoggerFactory.getLogger(OrderClient.class);
 
-	@Autowired
-	 RestTemplate restTemplate;
+	 RestTemplate restTemplate = new RestTemplate();;
 
 	@Autowired
 	private DiscoveryClient discoveryClient;


### PR DESCRIPTION
By default, if we inject RestTemplate in spring, it will enable ribbon for load balancing. Disable it by manually creating RestTemplate instance.
